### PR TITLE
WIP port of 2024 drive code, many TODOs

### DIFF
--- a/src/robot/commands/drive_forward_command.py
+++ b/src/robot/commands/drive_forward_command.py
@@ -5,18 +5,18 @@ from subsystems.drive_subsystem import DriveSubsystem
 
 # DriveForwardCommand Class
 class DriveForwardCommand(commands2.Command): 
-    def __init__(self, drive_subsystem:DriveSubsystem, duration:float, speed:float = 0.25):
+    def __init__(self, drive_subsystem:DriveSubsystem, duration:float, speed_inches_per_second:float = 12):
         super().__init__()
         self.drive_subsystem = drive_subsystem
         self.duration = duration # How long to run for
-        self.speed = speed  # Default speed is 0.5
+        self.speed = speed_inches_per_second  # Default speed is 12 inches per second
         self.timer = wpilib.Timer()
 
     def initialize(self):  # Setting function
         self.timer.start()
 
     def execute(self):  # What actions it does
-        self.drive_subsystem.drive(self.speed, self.speed)
+        self.drive_subsystem.drive(x_speed=self.speed, y_speed=self.speed, rot_speed=0)
 
     def isFinished(self) -> bool:
         if self.timer.hasElapsed(period=self.duration):
@@ -24,5 +24,5 @@ class DriveForwardCommand(commands2.Command):
         else:
             return False
 
-    def end(self, was_interupted:bool):  # Stop driving
-        self.drive_subsystem.drive(0.0, 0.0)
+    def end(self, was_interrupted:bool):  # Stop driving
+        self.drive_subsystem.drive(x_speed=0, y_speed=0, rot_speed=0)

--- a/src/robot/commands/drive_forward_command.py
+++ b/src/robot/commands/drive_forward_command.py
@@ -16,7 +16,7 @@ class DriveForwardCommand(commands2.Command):
         self.timer.start()
 
     def execute(self):  # What actions it does
-        self.drive_subsystem.drive(x_speed_inches_per_second=self.speed, y_speed_inches_per_second=self.speed, rot_speed_rotat=0)
+        self.drive_subsystem.drive(x_speed_inches_per_second=self.speed, y_speed_inches_per_second=self.speed, rot_speed_degrees_per_second=0)
 
     def isFinished(self) -> bool:
         if self.timer.hasElapsed(period=self.duration):
@@ -25,4 +25,4 @@ class DriveForwardCommand(commands2.Command):
             return False
 
     def end(self, was_interrupted:bool):  # Stop driving
-        self.drive_subsystem.drive(x_speed_inches_per_second=0, y_speed_inches_per_second=0, rot_speed_rotat=0)
+        self.drive_subsystem.drive(x_speed_inches_per_second=0, y_speed_inches_per_second=0, rot_speed_degrees_per_second=0)

--- a/src/robot/commands/drive_forward_command.py
+++ b/src/robot/commands/drive_forward_command.py
@@ -16,7 +16,7 @@ class DriveForwardCommand(commands2.Command):
         self.timer.start()
 
     def execute(self):  # What actions it does
-        self.drive_subsystem.drive(x_speed=self.speed, y_speed=self.speed, rot_speed=0)
+        self.drive_subsystem.drive(x_speed_inches_per_second=self.speed, y_speed_inches_per_second=self.speed, rot_speed_rotat=0)
 
     def isFinished(self) -> bool:
         if self.timer.hasElapsed(period=self.duration):
@@ -25,4 +25,4 @@ class DriveForwardCommand(commands2.Command):
             return False
 
     def end(self, was_interrupted:bool):  # Stop driving
-        self.drive_subsystem.drive(x_speed=0, y_speed=0, rot_speed=0)
+        self.drive_subsystem.drive(x_speed_inches_per_second=0, y_speed_inches_per_second=0, rot_speed_rotat=0)

--- a/src/robot/commands/drive_with_joystick_command.py
+++ b/src/robot/commands/drive_with_joystick_command.py
@@ -13,8 +13,8 @@ class DriveWithJoystickCommand(commands2.Command): #Class type command from the 
         self.addRequirements(drive) #Requires this subsystem
 
     def execute(self):  # What actions it does        
-        turn_speed, drive_speed = self.drive_percent_fn() #Set turn and drive speed to values got from function
-        self.drive_subsystem.drive(turn_speed, drive_speed) #Give these values to drive function
+        turn_speed, drive_speed, rot_speed = self.drive_percent_fn() #Set turn and drive speed to values got from function
+        self.drive_subsystem.drive(x_speed_inches_per_second=turn_speed, y_speed_inches_per_second=drive_speed, rot_speed_degrees_per_second=rot_speed) #Give these values to drive function
 
     def isFinished(self): #When something else happends then this is done, cause this is a default command
         return True

--- a/src/robot/commands/drive_with_joystick_command.py
+++ b/src/robot/commands/drive_with_joystick_command.py
@@ -13,8 +13,8 @@ class DriveWithJoystickCommand(commands2.Command): #Class type command from the 
         self.addRequirements(drive) #Requires this subsystem
 
     def execute(self):  # What actions it does        
-        turn_speed, drive_speed, rot_speed = self.drive_percent_fn() #Set turn and drive speed to values got from function
-        self.drive_subsystem.drive(x_speed_inches_per_second=turn_speed, y_speed_inches_per_second=drive_speed, rot_speed_degrees_per_second=rot_speed) #Give these values to drive function
+        x_speed, y_speed, rot_speed = self.drive_percent_fn() #Set turn and drive speed to values got from function
+        self.drive_subsystem.drive(x_speed_inches_per_second=y_speed, y_speed_inches_per_second=x_speed, rot_speed_degrees_per_second=rot_speed) #Give these values to drive function
 
     def isFinished(self): #When something else happends then this is done, cause this is a default command
         return True

--- a/src/robot/constants/driveconstants.py
+++ b/src/robot/constants/driveconstants.py
@@ -4,13 +4,13 @@ from dataclasses import dataclass, field
 @dataclass(frozen=True)
 class DriveConstants:
     """ Drivetrain related constants"""
-    #CAN bus IDs
+    # CANCoder CAN bus IDs
     CAN_FR = 11 # Front right        
     CAN_FL = 8 # Front left         
     CAN_BL = 5 # Back left           
     CAN_BR = 2 # Back right         
 
-    #offsets in rotations
+    # CANCoder (magnet) offsets in rotations
     BR_OFFSET = 0.454
     BL_OFFSET = -0.306
     FR_OFFSET = -0.450
@@ -26,6 +26,10 @@ class DriveConstants:
     TURN_FL = 7 # Front left 
     TURN_BL = 4 # Back left
     TURN_BR = 1 # Back right
+
+    # Pigeon2 gyro CAN bus ID
+    # TODO: replace with correct ID.
+    PIGEON_ID = 0
 
     # Drivetrain geometry, gearing, etc.
     TRACK_HALF_WIDTH = 0.18       # meters (36 cm track width)   #TODO: Double check these values 1/27/25
@@ -57,6 +61,6 @@ class DriveConstants:
     # ROT_MAX_A = 0.1   # Rotational maximum acceleration
     # ROT_POS_TOL = 0.1 # Rotational position tolerance
     # ROT_VEL_TOL = 0.1 # Rotational velocity tolerance
-    SWERVE_MODULE_TURN_PID_KP = 0.3 # TODO: This is just what it was in 2024 CrescendoSwerveModule.py line 81
-    SWERVE_MODULE_TURN_PID_KI = 0.0
-    SWERVE_MODULE_TURN_PID_KD = 0.0
+    # SWERVE_MODULE_TURN_PID_KP = 0.3 # TODO: This is just what it was in 2024 CrescendoSwerveModule.py line 81
+    # SWERVE_MODULE_TURN_PID_KI = 0.0
+    # SWERVE_MODULE_TURN_PID_KD = 0.0

--- a/src/robot/constants/driveconstants.py
+++ b/src/robot/constants/driveconstants.py
@@ -39,6 +39,7 @@ class DriveConstants:
     # TODO: This needs to be changed to our measured velocity at max voltage (place holder value is phoenix6 @ 12V according to above link)
     FREE_SPEED = 4.69 # m/s
 
+    MAX_SPEED_INCHES_PER_SECOND = 120 # inches per second
 
     # # PID controller constants (gains)
     # # Proportional constant only at the moment, all others assumed zero.
@@ -56,3 +57,6 @@ class DriveConstants:
     # ROT_MAX_A = 0.1   # Rotational maximum acceleration
     # ROT_POS_TOL = 0.1 # Rotational position tolerance
     # ROT_VEL_TOL = 0.1 # Rotational velocity tolerance
+    SWERVE_MODULE_TURN_PID_KP = 0.3 # TODO: This is just what it was in 2024 CrescendoSwerveModule.py line 81
+    SWERVE_MODULE_TURN_PID_KI = 0.0
+    SWERVE_MODULE_TURN_PID_KD = 0.0

--- a/src/robot/robot_container.py
+++ b/src/robot/robot_container.py
@@ -34,32 +34,16 @@ class RobotContainer:
 
         self.teleop_command = TurnToAngleCommand(self.drive_subsystem, lambda: True)
 
-        #DriveWithJoystickCommand(self.drive_subsystem, drive_percent_fn=self.get_drive_value_from_joystick)
-        
-        # DriveWithJoystickCommand(self.drive_subsystem, driving_percent=self.get_drive_value_from_joystick) #The teleop command is the drive with joystick commmand which takes the drive subsystem and the getting drive value function
-
         self.controller.a().onTrue(PrintSomethingCommand("WHEA A Button Pressed"))
         self.controller.b().onTrue(TurnToAngleCommand(self.drive_subsystem, lambda: True)) #for quick test 
 
         self.drive_subsystem.setDefaultCommand(self.teleop_command) #Set the teleop command as the default for drive subsystem
     
-    def get_auto_command(self):
+    def get_auto_command(self) -> commands2.Command:
         return self.autonomous_command
-
-    def set_45_degrees(self):
-        right_joystick_x = self.controller.getRightX() > abs(0.1)
-
-        right_joystick_x = applyDeadband(value=self.controller.getRightX(), deadband=0.1)
-
-        print(right_joystick_x)
-
-        return right_joystick_x
     
-    def get_drive_value_from_joystick(self):
-        turn_percent = self.controller.getLeftX()  #Get the joystick values 
-        drive_percent = self.controller.getLeftY()
-
-        turn_percent = applyDeadband(value=self.controller.getLeftY(), deadband=0.1) #Apply deadband to the values above            
+    def get_drive_value_from_joystick(self) -> tuple[float, float]:
+        turn_percent = applyDeadband(value=self.controller.getLeftY(), deadband=0.1) #Apply deadband to the values above
         drive_percent = applyDeadband(value=self.controller.getLeftX(), deadband=0.1)
 
         return turn_percent, drive_percent  #Gives us these variables when we call this function

--- a/src/robot/robot_container.py
+++ b/src/robot/robot_container.py
@@ -32,20 +32,21 @@ class RobotContainer:
         self.controller = CommandXboxController(OperatorInterfaceConstants.DRIVER_CONTROLLER_PORT)
         self.autonomous_command = DriveForwardCommand(self.drive_subsystem, duration=5)
 
-        self.teleop_command = TurnToAngleCommand(self.drive_subsystem, lambda: True)
+        self.teleop_command = DriveWithJoystickCommand(self.drive_subsystem, self.get_drive_value_from_joystick)
 
         self.controller.a().onTrue(PrintSomethingCommand("WHEA A Button Pressed"))
-        self.controller.b().onTrue(TurnToAngleCommand(self.drive_subsystem, lambda: True)) #for quick test 
+        self.controller.b().whileTrue(TurnToAngleCommand(self.drive_subsystem, lambda: True)) #for quick test 
 
         self.drive_subsystem.setDefaultCommand(self.teleop_command) #Set the teleop command as the default for drive subsystem
     
     def get_auto_command(self) -> commands2.Command:
         return self.autonomous_command
     
-    def get_drive_value_from_joystick(self) -> tuple[float, float]:
-        turn_percent = applyDeadband(value=self.controller.getLeftY(), deadband=0.1) #Apply deadband to the values above
-        drive_percent = applyDeadband(value=self.controller.getLeftX(), deadband=0.1)
+    def get_drive_value_from_joystick(self) -> tuple[float, float, float]:
+        turn_percent = applyDeadband(value=self.controller.getLeftX(), deadband=0.1) #Apply deadband to the values above
+        drive_percent = applyDeadband(value=self.controller.getLeftY(), deadband=0.1)
+        rot_percent = applyDeadband(value=self.controller.getRightX(), deadband=0.1)
 
-        return turn_percent, drive_percent  #Gives us these variables when we call this function
+        return turn_percent, drive_percent, rot_percent  #Gives us these variables when we call this function
     
 

--- a/src/robot/robot_container.py
+++ b/src/robot/robot_container.py
@@ -43,10 +43,10 @@ class RobotContainer:
         return self.autonomous_command
     
     def get_drive_value_from_joystick(self) -> tuple[float, float, float]:
-        turn_percent = applyDeadband(value=self.controller.getLeftX(), deadband=0.1) #Apply deadband to the values above
-        drive_percent = applyDeadband(value=self.controller.getLeftY(), deadband=0.1)
+        x_percent = applyDeadband(value=self.controller.getLeftX(), deadband=0.1) #Apply deadband to the values above
+        y_percent = applyDeadband(value=self.controller.getLeftY(), deadband=0.1)
         rot_percent = applyDeadband(value=self.controller.getRightX(), deadband=0.1)
 
-        return turn_percent, drive_percent, rot_percent  #Gives us these variables when we call this function
+        return x_percent, y_percent, rot_percent  #Gives us these variables when we call this function
     
 

--- a/src/robot/subsystems/drive_subsystem.py
+++ b/src/robot/subsystems/drive_subsystem.py
@@ -33,17 +33,7 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         self.BackLeftModule = self.modules[2]
         self.BackRightModule = self.modules[3]
 
-        # Either brake or coast, depending on motor configuration; we chose brake above.
-        self.brake_request = phoenix6.controls.NeutralOut()
-
-        # Position request starts at position 0, but can be modified later.
-        self.position_request = phoenix6.controls.PositionVoltage(0).with_slot(0)
-
-        # A motion magic (MM) position request. MM smooths the acceleration.
-        self.mm_pos_request = phoenix6.controls.MotionMagicVoltage(0).with_slot(1)
-
         self.kinematics = SwerveDrive4Kinematics(*self._get_module_translations())
-
         self.odometry = self._initialize_odometry(kinematics=self.kinematics)
 
         self.heartbeat = 0
@@ -117,18 +107,6 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
             cs = ChassisSpeeds(x_speed, y_speed, rot_speed)
         return cs
 
-    def _toggle_drive_motors_inverted(self):
-        for module in self.modules:
-            module.toggle_drive_inverted()
-
-    def _initialize_odometry(self, kinematics) -> SwerveDrive4Odometry:
-        module_positions = [module.get_position() for module in self.modules]
-        return SwerveDrive4Odometry(
-            kinematics=kinematics,
-            gyroAngle=self.get_drive_angle_rotation2d(),
-            modulePositions=[module.get_position() for module in self.modules]
-        )
-
     def _update_odometry(self):
         self.odometry.update(
             self.get_drive_angle_rotation2d(),
@@ -142,10 +120,10 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         [FrontRight, FrontLeft, BackLeft, BackRight]
 
         Returns:
-            list[Translation2d]: List of module positions in meters
+            list[Translation2d]: List of module positions in inches
         """
 
-        # TODO: Is inches correct unit?
+        # Using inches for the module positions
         half_length = metersToInches(DriveConstants.WHEELBASE_HALF_LENGTH)  # Convert to inches
         half_width = metersToInches(DriveConstants.TRACK_HALF_WIDTH)  # Convert to inches
 

--- a/src/robot/subsystems/drive_subsystem.py
+++ b/src/robot/subsystems/drive_subsystem.py
@@ -1,12 +1,9 @@
 import commands2
-import phoenix6
-import wpilib
 import wpimath
-from wpilib import SmartDashboard
-from wpimath.estimator import SwerveDrive4PoseEstimator
+from wpilib import SmartDashboard, Field2d
 from wpimath.geometry import Rotation2d
 from wpimath.kinematics import SwerveDrive4Kinematics, SwerveDrive4Odometry, ChassisSpeeds
-from wpimath.units import degrees, radians, meters, inches, metersToInches
+from wpimath.units import metersToInches
 
 from constants.driveconstants import DriveConstants
 from subsystems.swerve_module import SwerveModule
@@ -37,6 +34,11 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         self.odometry = self._initialize_odometry(kinematics=self.kinematics)
 
         self.heartbeat = 0
+
+        # Simulation support
+        self.field_sim = Field2d()
+        SmartDashboard.putData('Field', self.field_sim)
+
     # Sets the drive to the given speed and rotation, expressed as percentages
     # of full speed. The speed and rotation values range from -1 to 1.
     # Note that the drive will continue at those values until told otherwise
@@ -106,6 +108,13 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         else:
             cs = ChassisSpeeds(x_speed, y_speed, rot_speed)
         return cs
+
+    def _initialize_odometry(self, kinematics: SwerveDrive4Kinematics) -> SwerveDrive4Odometry:
+        return SwerveDrive4Odometry(
+            kinematics=kinematics,
+            gyroAngle=self.get_drive_angle_rotation2d(),
+            modulePositions=[module.get_position() for module in self.modules]
+        )
 
     def _update_odometry(self):
         self.odometry.update(

--- a/src/robot/subsystems/drive_subsystem.py
+++ b/src/robot/subsystems/drive_subsystem.py
@@ -82,7 +82,7 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         """
         # TODO: From the gyro. For now, just return the BL module's angle
         # return self.gyro.get_yaw().value
-        return self.BackLeftModule.get_turn_angle_degrees()
+        return 0.0
 
     def get_heading_rotation2d(self) -> Rotation2d:
         """
@@ -124,7 +124,7 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         # Update field sim
         self.field_sim.setRobotPose(pose)
         # TODO: Compare to 2024's self.fieldSim.getObject("Swerve Modules").setPoses(self.module_poses)
-        self.field_sim.setModuleStates([module.get_state() for module in self.modules])
+        # self.field_sim.setModuleStates([module.get_state() for module in self.modules])
 
 
     def drive(self, x_speed_inches_per_second : inches_per_second, y_speed_inches_per_second : inches_per_second, rot_speed_degrees_per_second: degrees_per_second) -> None:

--- a/src/robot/subsystems/drive_subsystem.py
+++ b/src/robot/subsystems/drive_subsystem.py
@@ -47,43 +47,6 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         self.odometry = self._initialize_odometry(kinematics=self.kinematics)
 
         self.heartbeat = 0
-
-    def _initialize_odometry(self, kinematics) -> SwerveDrive4Odometry:
-        module_positions = [module.get_position() for module in self.modules]
-        return SwerveDrive4Odometry(
-            kinematics=kinematics,
-            gyroAngle=self.get_drive_angle_rotation2d(),
-            modulePositions=[module.get_position() for module in self.modules]
-        )
-
-    def _get_module_translations(self) -> list[wpimath.geometry.Translation2d]:
-        """
-        Returns the physical positions of each swerve module relative to the center of the robot.
-        The order should match the order of modules in self.modules:
-        [FrontRight, FrontLeft, BackLeft, BackRight]
-
-        Returns:
-            list[Translation2d]: List of module positions in meters
-        """
-
-        # TODO: Is inches correct unit?
-        half_length = metersToInches(DriveConstants.WHEELBASE_HALF_LENGTH)# Convert to inches
-        half_width = metersToInches(DriveConstants.TRACK_HALF_WIDTH) # Convert to inches
-
-        # Create Translation2d objects for each module position
-        # The coordinate system is:
-        # - Positive x is forward
-        # - Positive y is left
-        # - Origin (0,0) is at robot center
-        translations = [
-            wpimath.geometry.Translation2d(half_length, -half_width),  # Front Right
-            wpimath.geometry.Translation2d(half_length, half_width),  # Front Left
-            wpimath.geometry.Translation2d(-half_length, half_width),  # Back Left
-            wpimath.geometry.Translation2d(-half_length, -half_width),  # Back Right
-        ]
-
-        return translations
-
     # Sets the drive to the given speed and rotation, expressed as percentages
     # of full speed. The speed and rotation values range from -1 to 1.
     # Note that the drive will continue at those values until told otherwise
@@ -126,3 +89,40 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
 
         SmartDashboard.putNumber("Heartbeat", self.heartbeat)
         self.heartbeat += 1
+
+    def _initialize_odometry(self, kinematics) -> SwerveDrive4Odometry:
+        module_positions = [module.get_position() for module in self.modules]
+        return SwerveDrive4Odometry(
+            kinematics=kinematics,
+            gyroAngle=self.get_drive_angle_rotation2d(),
+            modulePositions=[module.get_position() for module in self.modules]
+        )
+
+    def _get_module_translations(self) -> list[wpimath.geometry.Translation2d]:
+        """
+        Returns the physical positions of each swerve module relative to the center of the robot.
+        The order should match the order of modules in self.modules:
+        [FrontRight, FrontLeft, BackLeft, BackRight]
+
+        Returns:
+            list[Translation2d]: List of module positions in meters
+        """
+
+        # TODO: Is inches correct unit?
+        half_length = metersToInches(DriveConstants.WHEELBASE_HALF_LENGTH)  # Convert to inches
+        half_width = metersToInches(DriveConstants.TRACK_HALF_WIDTH)  # Convert to inches
+
+        # Create Translation2d objects for each module position
+        # The coordinate system is:
+        # - Positive x is forward
+        # - Positive y is left
+        # - Origin (0,0) is at robot center
+        translations = [
+            wpimath.geometry.Translation2d(half_length, -half_width),  # Front Right
+            wpimath.geometry.Translation2d(half_length, half_width),  # Front Left
+            wpimath.geometry.Translation2d(-half_length, half_width),  # Back Left
+            wpimath.geometry.Translation2d(-half_length, -half_width),  # Back Right
+        ]
+
+        return translations
+

--- a/src/robot/subsystems/drive_subsystem.py
+++ b/src/robot/subsystems/drive_subsystem.py
@@ -5,15 +5,12 @@ import wpimath
 from wpilib import SmartDashboard, Field2d
 from wpimath.geometry import Rotation2d
 from wpimath.kinematics import SwerveDrive4Kinematics, SwerveDrive4Odometry, ChassisSpeeds
-from wpimath.units import metersToInches, inchesToMeters, degreesToRadians
+from wpimath.units import metersToInches, inchesToMeters, degreesToRadians, degrees
 
 # This is for type hinting. You can use these types to make your code more readable and maintainable.
 # There will be a warning (but not an error!) if you try to assign a value of the wrong type to a variable
-inches = NewType("inches", float)
-degrees = NewType("degrees", float)
 inches_per_second = NewType("inches_per_second", float)
 degrees_per_second = NewType("degrees_per_second", float)
-
 
 from constants.driveconstants import DriveConstants
 from subsystems.swerve_module import SwerveModule
@@ -63,7 +60,7 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
            module.set_turn_angle(desired_angle_degrees)
 
     def get_drive_angle_degrees(self) -> degrees:
-        # Probably from the gyro? Or kinematics? For now, just return the BL module's angle
+        # TODO: Probably from the gyro? Or kinematics? For now, just return the BL module's angle
         return self.BackLeftModule.get_turn_angle_degrees()
 
     def get_drive_angle_rotation2d(self) -> Rotation2d:
@@ -98,8 +95,8 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         self.field_sim.setModuleStates([module.get_state() for module in self.modules])
 
 
-    def drive(self, x_speed : inches_per_second, y_speed : inches_per_second, rot_speed : degrees_per_second) -> None:
-        desatured_module_states = self._speeds_to_states(x_speed, y_speed, rot_speed)
+    def drive(self, x_speed_inches_per_second : inches_per_second, y_speed_inches_per_second : inches_per_second, rot_speed_rotations_per_second: degrees_per_second) -> None:
+        desatured_module_states = self._speeds_to_states(x_speed_inches_per_second, y_speed_inches_per_second, rot_speed_rotations_per_second)
         for module, state in zip(self.modules, desatured_module_states):
             module.set_desired_state(state, True)
 

--- a/src/robot/subsystems/drive_subsystem.py
+++ b/src/robot/subsystems/drive_subsystem.py
@@ -172,12 +172,6 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
             modulePositions=[module.get_position() for module in self.modules]
         )
 
-    # def _update_odometry(self):
-    #     self.odometry.update(
-    #         self.get_heading_rotation2d(),
-    #         tuple([module.get_position() for module in self.modules])
-    #     )
-
     def _get_module_translations(self) -> list[wpimath.geometry.Translation2d]:
         """
         Returns the physical positions of each swerve module relative to the center of the robot.

--- a/src/robot/subsystems/drive_subsystem.py
+++ b/src/robot/subsystems/drive_subsystem.py
@@ -1,9 +1,19 @@
+from typing import NewType
+
 import commands2
 import wpimath
 from wpilib import SmartDashboard, Field2d
 from wpimath.geometry import Rotation2d
 from wpimath.kinematics import SwerveDrive4Kinematics, SwerveDrive4Odometry, ChassisSpeeds
-from wpimath.units import metersToInches
+from wpimath.units import metersToInches, inchesToMeters, degreesToRadians
+
+# This is for type hinting. You can use these types to make your code more readable and maintainable.
+# There will be a warning (but not an error!) if you try to assign a value of the wrong type to a variable
+inches = NewType("inches", float)
+degrees = NewType("degrees", float)
+inches_per_second = NewType("inches_per_second", float)
+degrees_per_second = NewType("degrees_per_second", float)
+
 
 from constants.driveconstants import DriveConstants
 from subsystems.swerve_module import SwerveModule
@@ -42,17 +52,17 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
     # Sets the drive to the given speed and rotation, expressed as percentages
     # of full speed. The speed and rotation values range from -1 to 1.
     # Note that the drive will continue at those values until told otherwise
-    def drive(self, drive_speed:float, turn_speed:float) -> None:
+    def drive_by_effort(self, drive_speed:inches_per_second, turn_speed:degrees_per_second) -> None:
         for module in self.modules:
             module.set_drive_effort(drive_speed)
             module.set_turn_effort(turn_speed)
 
-    def set_drive_angle(self, desired_angle_degrees):
+    def set_drive_angle(self, desired_angle_degrees : degrees) -> None:
         # Probably:
         for module in self.modules:
            module.set_turn_angle(desired_angle_degrees)
 
-    def get_drive_angle_degrees(self) -> float:
+    def get_drive_angle_degrees(self) -> degrees:
         # Probably from the gyro? Or kinematics? For now, just return the BL module's angle
         return self.BackLeftModule.get_turn_angle_degrees()
 
@@ -88,25 +98,23 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         self.field_sim.setModuleStates([module.get_state() for module in self.modules])
 
 
-    # TODO: What are the units for x_speed, y_speed, rot_speed? Are they inches/sec and degrees/sec? Do they need to be
-    def drive(self, x_speed : float, y_speed : float, rot_speed : float, field_relative : bool = False):
-        chassis_speeds = self._get_chassis_speeds(x_speed, y_speed, rot_speed, field_relative)
-        swerve_module_states = self.kinematics.toSwerveModuleStates(chassis_speeds)
-        # TODO: Do we need to convert from inches/sec?
-        desatured_module_states = SwerveDrive4Kinematics.desaturateWheelSpeeds(swerve_module_states, DriveConstants.MAX_SPEED_INCHES_PER_SECOND)
+    def drive(self, x_speed : inches_per_second, y_speed : inches_per_second, rot_speed : degrees_per_second) -> None:
+        desatured_module_states = self._speeds_to_states(x_speed, y_speed, rot_speed)
         for module, state in zip(self.modules, desatured_module_states):
             module.set_desired_state(state, True)
 
     def get_pose(self) -> wpimath.geometry.Pose2d:
         return self.odometry.getPose()
 
-    # TODO: What are units for x_speed, y_speed, rot_speed? Are they inches/sec and degrees/sec? Do they need to be
-    #  converted for wpilib.kinematics.ChassisSpeeds?
-    def _get_chassis_speeds(self, x_speed: float, y_speed: float, rot_speed: float, field_relative: bool) -> ChassisSpeeds:
+    def _get_chassis_speeds(self, x_speed_inches_per_second: inches_per_second, y_speed_inches_per_second:  inches_per_second, rot_speed_degrees_per_second: degrees_per_second, field_relative: bool = True) -> ChassisSpeeds:
+        # ChassisSpeeds expects meters and radians
+        x_speed_meters_per_second = inchesToMeters(x_speed_inches_per_second)
+        y_speed_meters_per_second = inchesToMeters(y_speed_inches_per_second)
+        rot_speed_radians = degreesToRadians(rot_speed_degrees_per_second)
         if field_relative:
-            cs = ChassisSpeeds.fromRobotRelativeSpeeds(x_speed, y_speed, rot_speed, self.get_drive_angle_rotation2d())
+            cs = ChassisSpeeds.fromRobotRelativeSpeeds(x_speed_meters_per_second, y_speed_meters_per_second, rot_speed_radians, self.get_drive_angle_rotation2d())
         else:
-            cs = ChassisSpeeds(x_speed, y_speed, rot_speed)
+            cs = ChassisSpeeds(x_speed_meters_per_second, y_speed_meters_per_second, rot_speed_radians)
         return cs
 
     def _initialize_odometry(self, kinematics: SwerveDrive4Kinematics) -> SwerveDrive4Odometry:
@@ -149,4 +157,10 @@ class DriveSubsystem(commands2.Subsystem):  # Name what type of class this is
         ]
 
         return translations
+
+    def _speeds_to_states(self, x_speed : inches_per_second, y_speed : inches_per_second, rot_speed : degrees_per_second) -> list[SwerveModule.State]:
+        chassis_speeds = self._get_chassis_speeds(x_speed_inches_per_second=x_speed, y_speed_inches_per_second=y_speed, rot_speed=rot_speed, field_relative=True)
+        swerve_module_states = self.kinematics.toSwerveModuleStates(chassis_speeds)
+        desatured_module_states = SwerveDrive4Kinematics.desaturateWheelSpeeds(swerve_module_states, DriveConstants.MAX_SPEED_INCHES_PER_SECOND)
+        return desatured_module_states
 

--- a/src/robot/subsystems/swerve_module.py
+++ b/src/robot/subsystems/swerve_module.py
@@ -241,6 +241,14 @@ class SwerveModule:
 
         return SwerveModuleState(optimized_target_speed, Rotation2d.fromDegrees(optimized_target_angle))
 
+    def _calc_drive_effort(self, speed : inches_per_second, open_loop: bool = True) -> percentage:
+        if open_loop:
+            drive_effort = speed / DriveConstants.MAX_SPEED_INCHES_PER_SECOND
+            drive_effort_clamped = max(min(drive_effort, 1.0), -1.0)
+        else:
+            raise NotImplementedError("Closed loop control not yet implemented")
+        return drive_effort_clamped
+
     def _degrees_to_turn_count(self, degrees: degrees) -> float:
         rotations = degreesToRotations(degrees)
         return rotations * DriveConstants.TURN_GEAR_RATIO
@@ -258,12 +266,4 @@ class SwerveModule:
         # Convert by gear ratio TODO: Is this correct?
         ratioed_rotations = motor_abs_pct_rotated / DriveConstants.TURN_GEAR_RATIO
         return rotationsToDegrees(ratioed_rotations)
-
-    def _calc_drive_effort(self, speed : inches_per_second, open_loop: bool = True) -> percentage:
-        if open_loop:
-            drive_effort = speed / DriveConstants.MAX_SPEED_INCHES_PER_SECOND
-            drive_effort_clamped = max(min(drive_effort, 1.0), -1.0)
-        else:
-            raise NotImplementedError("Closed loop control not yet implemented")
-        return drive_effort_clamped
 

--- a/src/robot/subsystems/swerve_module.py
+++ b/src/robot/subsystems/swerve_module.py
@@ -50,7 +50,7 @@ class SwerveModule:
         self.drive_motor.set(speed_pct)
 
     # Returns percentage of full driving speed (range -1 to 1)
-    def get_drive_effort(self):
+    def get_drive_effort(self) -> float:
         return self.drive_motor.get()
 
     # Sets the turn to the given speed, expressed as a percentage of full speed (range -1 to 1).
@@ -58,10 +58,10 @@ class SwerveModule:
         self.turn_motor.set(speed_pct)
 
     # Returns percentage of full turning speed (range -1 to 1)
-    def get_turn_effort(self):
+    def get_turn_effort(self) -> float:
         return self.turn_motor.get()
 
-    def velocity_from_effort(self, effort_pct):
+    def velocity_from_effort(self, effort_pct: float) -> float:
         effort = max(min(effort_pct, 1.0), -1.0)
 
         # Conversion using feed forward
@@ -112,11 +112,9 @@ class SwerveModule:
         # Argument units per https://robotpy.readthedocs.io/projects/wpimath/en/latest/wpimath.kinematics/SwerveModulePosition.html
         return SwerveModulePosition(distance, angle)
 
-
     def periodic(self):
-        module_name = f"Module @ Bus {self.name}"
-        wpilib.SmartDashboard.putString(f"{module_name}_turn_degrees", 'degrees: {:5.1f}'.format(self.get_turn_angle_degrees()))
-        wpilib.SmartDashboard.putString(f"{module_name}_can_coder_pos_rotations", 'rotations: {:5.3f}'.format(self._get_can_coder_pos_normalized()))
+        wpilib.SmartDashboard.putString(f"{self.name}_turn_degrees", 'degrees: {:5.1f}'.format(self.get_turn_angle_degrees()))
+        wpilib.SmartDashboard.putString(f"{self.name}_can_coder_pos_rotations", 'rotations: {:5.3f}'.format(self._get_can_coder_pos_normalized()))
 
     def _inches_per_rotation(self) -> inches:
         return DriveConstants.WHEEL_RADIUS * 2 * 3.14159

--- a/src/robot/subsystems/swerve_module.py
+++ b/src/robot/subsystems/swerve_module.py
@@ -167,3 +167,21 @@ class SwerveModule:
     def _max_velocity_inches_per_second(self) -> inches:
         free_speed_inches_per_second = metersToInches(DriveConstants.FREE_SPEED)
 
+    def _optimize(self, desired_state: SwerveModuleState, current_rotation: float) -> SwerveModuleState:
+        target_angle = desired_state.angle.degrees()
+        target_speed = desired_state.speed
+        delta_degrees = target_angle - rotationsToDegrees(current_rotation)
+
+        if abs(delta_degrees) > 90:
+            optimized_target_speed = -target_speed
+            if delta_degrees > 90:
+                # Delta is positive
+                optimized_target_angle = target_angle - 180
+            else:
+                # Delta is negative
+                optimized_target_angle = target_angle + 180
+        else:
+            optimized_target_speed = target_speed
+            optimized_target_angle = target_angle
+
+        return SwerveModuleState(optimized_target_speed, Rotation2d.fromDegrees(optimized_target_angle))

--- a/src/robot/subsystems/swerve_module.py
+++ b/src/robot/subsystems/swerve_module.py
@@ -185,3 +185,7 @@ class SwerveModule:
             optimized_target_angle = target_angle
 
         return SwerveModuleState(optimized_target_speed, Rotation2d.fromDegrees(optimized_target_angle))
+
+    def _degrees_to_turn_count(self, degrees: float) -> float:
+        rotations = degreesToRotations(degrees)
+        return rotations * DriveConstants.TURN_GEAR_RATIO

--- a/src/robot/subsystems/swerve_module.py
+++ b/src/robot/subsystems/swerve_module.py
@@ -156,6 +156,7 @@ class SwerveModule:
         optimized_state = self._optimize(desired_state, current_rotation)
 
         drive_effort = self._calc_drive_effort(metersToInches(optimized_state.speed)) # SwerveModuleStates use meters/second
+        wpilib.SmartDashboard.putString(f"{self.name}_drive_effort", '{:5.2f}'.format(drive_effort))
         geared_rotations = self._degrees_to_turn_count(optimized_state.angle.degrees())
         request = self.position_request.with_position(geared_rotations)
 

--- a/src/robot/subsystems/swerve_module.py
+++ b/src/robot/subsystems/swerve_module.py
@@ -113,7 +113,7 @@ class SwerveModule:
         # effort : percentage = self.get_drive_effort()  # Replace with actual drive velocity in m/s
         # speed : inches_per_second = self.velocity_from_effort(effort)
         wheel_rps = self.drive_motor.get_velocity().value / DriveConstants.DRIVE_GEAR_RATIO # wheel rotations per second.
-        speed_mps : meters_per_second = inchesToMeters(self._inches_per_rotation(wheel_rps))
+        speed_mps : meters_per_second = inchesToMeters(self._inches_per_rotation() * wheel_rps)
 
         # I might be inclined to get this from the turn motor encoder rather than CANCoder, but either will work.
         angle = wpimath.geometry.Rotation2d().fromDegrees(self.get_turn_angle_degrees())
@@ -140,7 +140,7 @@ class SwerveModule:
         """
         Reports module data to dashboards.
         """
-        wpilib.SmartDashboard.putString(f"{self.name}_turn_degrees", 'degrees: {:5.1f}'.format(self.get_turn_angle_degrees()))
+        wpilib.SmartDashboard.putString(f"{self.name}_turn_degrees", 'degrees: {:5.1f}'.format(self._get_full_turn_angle_from_motor()))
         wpilib.SmartDashboard.putString(f"{self.name}_can_coder_pos_rotations", 'rotations: {:5.3f}'.format(self._get_can_coder_pos_normalized()))
 
     def set_desired_state(self, desired_state: SwerveModuleState) -> None:
@@ -172,7 +172,7 @@ class SwerveModule:
     def _configure_turn_motor(self) -> TalonFXConfiguration:
         configuration = TalonFXConfiguration()
 
-        configuration.motor_output.inverted = InvertedValue.COUNTER_CLOCKWISE_POSITIVE
+        configuration.motor_output.inverted = InvertedValue.CLOCKWISE_POSITIVE
         configuration.motor_output.neutral_mode = NeutralModeValue.COAST
 
         # Set control loop parameters for "slot 0", the profile we'll use for position control.
@@ -190,7 +190,7 @@ class SwerveModule:
     def _configure_drive_motor(self) -> TalonFXConfiguration:
         configuration = TalonFXConfiguration()
 
-        configuration.motor_output.inverted = InvertedValue.CLOCKWISE_POSITIVE
+        configuration.motor_output.inverted = InvertedValue.COUNTER_CLOCKWISE_POSITIVE
         configuration.motor_output.neutral_mode = NeutralModeValue.BRAKE
 
         return configuration


### PR DESCRIPTION
First 3 commits (moving functions, port optimize() fn and port _degrees_to_turn_count() are probably okay. 

Last commit relating to PIDController raises a bunch of TODOs and questions:

[ ] DriveConstants.MAX_SPEED_INCHES_PER_SECOND vs 2024's MAX_SPEED = 5. Just using 120 in/s as a placeholder. Guessing 5 was 5 m/s? 

[ ] DriveConstants PID constants for Swerve Module Turn: is this correct? Each SM gets a PID Controller? Looks like it did in 2024 (P was 0.3)

[ ] SM PID Controller in 2024 had several calls I don't see in API: SwerveModule.py LL 54-58 

[ ] SM `set_desired_state()` varies from 2024. 2024 ended with a call to `setReference` which I don't think is in Phoenix6. I used set_control(position_request) but am very unsure if this is correct

[ ]  DriveSubsystem L95 needs check (2024: getObject("Swerve Modules").setPoses() vs. 2025 setModuleStates

[ ]  DriveSubsystem drive() LL100-118 has lots of unit worries: x_speed, y_speed, rot as floats. Are units in/s deg/s? 

 
